### PR TITLE
fixed matrixD update

### DIFF
--- a/pytoolbox/network/smpte2022/receiver.py
+++ b/pytoolbox/network/smpte2022/receiver.py
@@ -285,7 +285,7 @@ class FecReceiver(object):
             media_test = (media_test + fec.offset) & RtpPacket.S_MASK
         if fec.L != 0:
             self.matrixL = fec.L
-        if fec.D != 0:
+        if fec.D != 0 and fec.D != None:
             self.matrixD = fec.D
         # [1] The fec packet is useless if none of the protected media packets is missing
         if len(fec.missing) == 0:

--- a/pytoolbox/network/smpte2022/receiver.py
+++ b/pytoolbox/network/smpte2022/receiver.py
@@ -472,9 +472,9 @@ class FecReceiver(object):
                 cross = self.crosses.get(self.position)
                 if cross:
                     del self.crosses[self.position]
-                    if cross['col_sequence']:
+                    if cross['col_sequence'] and cross['col_sequence'] in self.cols:
                         del self.cols[cross['col_sequence']]
-                    if cross['row_sequence']:
+                    if cross['row_sequence'] and cross['row_sequence'] in self.rows:
                         del self.rows[cross['row_sequence']]
         # Extract packets to output in order to keep a 'certain' amount of them in the buffer
         elif units == FecReceiver.SECONDS:  # based on time stamps


### PR DESCRIPTION
If the FEC packet is of type row, fec.D() returns None, which is not a valid integer. This oversight also causes the program to crash due to invalid TypeError during print.