### PR TITLE
Update smpte2022 fastxor usage for python 3.9+

### DIFF
--- a/pytoolbox/network/smpte2022/base.py
+++ b/pytoolbox/network/smpte2022/base.py
@@ -536,10 +536,10 @@ class FecPacket(object):  # pylint:disable=too-many-instance-attributes
             if len(packet.payload) < size:
                 payload = payload + bytearray(size - len(packet.payload))
 
-            fast_xor_inplace(fec.payload_recovery, payload)
+            fast_xor_inplace(fec.payload_recovery, bytearray(payload))
             # NUMPY fec.payload_recovery = bytearray(
-            #     numpy.bitwise_xor(fec.payload_recovery, payload))
-            # XOR LOOP for i in xrange(min(size, len(packet.payload))):
+            #     numpy.bitwise_xor(fec.payload_recovery, bytearray(payload)))
+            # XOR LOOP for i in range(min(size, len(packet.payload))):
             # XOR LOOP     fec.payload_recovery[i] ^= packet.payload[i]
         return fec
 


### PR DESCRIPTION
Hi David

I tested and used your code, works perfectly, many thanks.
Sending you an update, which I had to do, to use your code with python 3.9 and newer (but maybe even older python version would needed it, I didn't test  for 3.8 and bellow).

Best wishes
Julius